### PR TITLE
v3.3.5 - Optimize EventStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.3.5
+
+- `EventStream`:
+  - Changed `_controller` field to nullable `_controllerObj` and lazily initialized it.
+  - Changed `_stream` field to nullable `_streamObj` and lazily initialized it as a broadcast stream.
+  - Updated `add` and `addError` methods to check `isUsed` (based on `_streamObj` presence) before adding events.
+  - Updated `close`, `isClosed`, and `isPaused` to handle nullable `_controllerObj`.
+  - Added `isUsed` getter to indicate if the stream has been used (initialized).
+
+- `pubspec.yaml`:
+  - Updated `dependency_validator` version from `^5.0.3` to `^5.0.4`.
+
 ## 3.3.4
 
 - Added `WeakKeyMap` and `DualWeakMap` classes in `weak_map.dart`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   - Updated `close`, `isClosed`, and `isPaused` to handle nullable `_controllerObj`.
   - Added `isUsed` getter to indicate if the stream has been used (initialized).
 
+- New `FlatHashMap`:
+  - Flat, index-based hash map with contiguous storage, free-list reuse, and
+    adaptive unsigned chain pointers for reduced memory and improved cache locality.
+
 - `pubspec.yaml`:
   - Updated `dependency_validator` version from `^5.0.3` to `^5.0.4`.
 

--- a/lib/src/flat_hash_map.dart
+++ b/lib/src/flat_hash_map.dart
@@ -1,0 +1,308 @@
+import 'dart:collection';
+import 'dart:typed_data';
+
+class FlatHashMap<K extends Object, V extends Object> extends MapBase<K, V> {
+  static const int _maskRemoveNegativeSign = 0x7FFFFFFF;
+
+  static int _groupIndex(int objHashcode, int totalGroups) {
+    return (objHashcode & _maskRemoveNegativeSign) % totalGroups;
+  }
+
+  int _size = 0;
+
+  List<K?> _chainKey = [];
+  List<V?> _chainVal = [];
+
+  int _chainLength = 0;
+  Uint32List _chainHash = Uint32List(8);
+  TypedDataList<int> _chainNext = _newUIntList(8, 8);
+
+  int _chainRemoved = 0;
+
+  Uint32List _groups;
+  Uint32List _groupsSizes;
+
+  FlatHashMap()
+      : _groups = Uint32List(8),
+        _groupsSizes = Uint32List(8) {
+    _skipFirstChainPos();
+  }
+
+  int get capacity => _chainNext.length;
+
+  int get capacityBits {
+    if (_chainNext is Uint8List) {
+      return 8;
+    } else if (_chainNext is Uint16List) {
+      return 16;
+    } else if (_chainNext is Uint32List) {
+      return 32;
+    } else if (_chainNext is Uint64List) {
+      return 64; // VM only
+    }
+
+    throw StateError('Unknown TypedDataList type: ${_chainNext.runtimeType}');
+  }
+
+  static TypedDataList<int> _newUIntList(int length, int maxN) {
+    if (maxN <= 0xFF) {
+      return Uint8List(length);
+    } else if (maxN <= 0xFFFF) {
+      return Uint16List(length);
+    } else if (maxN <= 0xFFFFFFFF) {
+      return Uint32List(length);
+    } else {
+      return Uint64List(length); // VM only
+    }
+  }
+
+  Uint32List _expandUint32List(Uint32List l, int newCapacity) {
+    final capacity = l.length;
+    assert(newCapacity > capacity, "$newCapacity > $capacity");
+    var l2 = Uint32List(newCapacity);
+    l2.setRange(0, capacity, l);
+    return l2;
+  }
+
+  TypedDataList<int> _expandUIntList(TypedDataList<int> l, int newCapacity) {
+    var l2 = _newUIntList(newCapacity, newCapacity);
+    l2.setRange(0, l.length, l);
+    return l2;
+  }
+
+  void _addEntry(int groupPos, int objHash, K? key, V? value) {
+    if (_chainLength >= _chainNext.length) {
+      var newCapacity = _chainNext.length * 2;
+      _chainHash = _expandUint32List(_chainHash, newCapacity);
+      _chainNext = _expandUIntList(_chainNext, newCapacity);
+    }
+
+    _chainNext[_chainLength] = groupPos;
+    _chainHash[_chainLength] = objHash;
+    ++_chainLength;
+
+    _chainKey.add(key);
+    _chainVal.add(value);
+  }
+
+  void _skipFirstChainPos() {
+    // index 0 is reserved as null/end
+    _addEntry(0, 0, null, null);
+  }
+
+  int memory() {
+    return (_chainKey.length * 64) +
+        (_chainVal.length * 64) +
+        (_chainHash.length * 64) +
+        (_chainNext.length * 64);
+  }
+
+  @override
+  int get length => _size;
+
+  @override
+  bool get isEmpty => _size == 0;
+
+  @override
+  bool containsKey(Object? key) {
+    if (key == null) return false;
+
+    final objHash = key.hashCode;
+    final groupIdx = _groupIndex(objHash, _groups.length);
+
+    var pos = _groups[groupIdx];
+    while (pos > 0) {
+      if (_chainHash[pos] == objHash && key == _chainKey[pos]) {
+        return true;
+      }
+      pos = _chainNext[pos];
+    }
+    return false;
+  }
+
+  @override
+  bool containsValue(Object? value) => _chainVal.contains(value);
+
+  @override
+  V? operator [](Object? key) => get(key);
+
+  V? get(Object? key) {
+    if (key == null) return null;
+
+    final objHash = key.hashCode;
+    final groupIdx = _groupIndex(objHash, _groups.length);
+
+    var pos = _groups[groupIdx];
+    while (pos > 0) {
+      if (_chainHash[pos] == objHash && key == _chainKey[pos]) {
+        return _chainVal[pos];
+      }
+      pos = _chainNext[pos];
+    }
+    return null;
+  }
+
+  @override
+  void operator []=(K key, V value) {
+    put(key, value);
+  }
+
+  V? put(K key, V value) {
+    final objHash = key.hashCode;
+    final groupIdx = _groupIndex(objHash, _groups.length);
+
+    final groupPos = _groups[groupIdx];
+    var cursor = groupPos;
+
+    while (cursor > 0) {
+      if (_chainHash[cursor] == objHash && key == _chainKey[cursor]) {
+        final prev = _chainVal[cursor];
+        _chainKey[cursor] = key;
+        _chainVal[cursor] = value;
+        return prev;
+      }
+      cursor = _chainNext[cursor];
+    }
+
+    int newPos;
+    if (_chainRemoved > 0) {
+      newPos = _chainRemoved;
+      _chainRemoved = _chainNext[newPos];
+
+      _chainNext[newPos] = groupPos;
+      _chainHash[newPos] = objHash;
+      _chainKey[newPos] = key;
+      _chainVal[newPos] = value;
+    } else {
+      newPos = _chainLength;
+
+      _addEntry(groupPos, objHash, key, value);
+    }
+
+    _groups[groupIdx] = newPos;
+    _groupsSizes[groupIdx]++;
+    _size++;
+
+    _checkRehashNeeded();
+    return null;
+  }
+
+  @override
+  V? remove(Object? key) {
+    if (key == null) return null;
+
+    final objHash = key.hashCode;
+    final groupIdx = _groupIndex(objHash, _groups.length);
+
+    var prevPos = 0;
+    var pos = _groups[groupIdx];
+
+    while (pos > 0) {
+      if (_chainHash[pos] == objHash && key == _chainKey[pos]) {
+        _chainKey[pos] = null;
+        final prev = _chainVal[pos];
+        _chainVal[pos] = null;
+
+        final next = _chainNext[pos];
+        if (prevPos > 0) {
+          _chainNext[prevPos] = next;
+        } else {
+          _groups[groupIdx] = next;
+        }
+
+        _groupsSizes[groupIdx]--;
+        _size--;
+
+        _chainNext[pos] = _chainRemoved;
+        _chainRemoved = pos;
+
+        return prev;
+      }
+      prevPos = pos;
+      pos = _chainNext[pos];
+    }
+    return null;
+  }
+
+  void _checkRehashNeeded() {
+    if (_size > _groups.length * 10) {
+      _rehash(_groups.length * 2);
+    }
+  }
+
+  void _rehash(int totalGroups) {
+    if (_groups.length == totalGroups) return;
+
+    final groups2 = Uint32List(totalGroups);
+    final groupsSizes2 = Uint32List(totalGroups);
+
+    final sz = _size + 1;
+    for (var i = 1; i < sz; i++) {
+      final key = _chainKey[i];
+      if (key == null) continue;
+
+      final objHash = key.hashCode;
+      final groupIdx = _groupIndex(objHash, totalGroups);
+
+      final prevPos = groups2[groupIdx];
+      groups2[groupIdx] = i;
+      groupsSizes2[groupIdx]++;
+      _chainNext[i] = prevPos;
+    }
+
+    _groups = groups2;
+    _groupsSizes = groupsSizes2;
+  }
+
+  @override
+  void clear({bool full = false}) {
+    _size = 0;
+
+    if (full) {
+      _chainKey = [];
+      _chainVal = [];
+      _chainHash = Uint32List(8);
+      _chainNext = _newUIntList(8, 8);
+    } else {
+      _chainKey.clear();
+      _chainVal.clear();
+      _chainHash.fillRange(0, _chainLength, 0);
+      _chainNext.fillRange(0, _chainLength, 0);
+    }
+
+    _chainLength = 0;
+
+    _groups = Uint32List(8);
+    _groupsSizes = Uint32List(8);
+    _chainRemoved = 0;
+
+    _skipFirstChainPos();
+  }
+
+  @override
+  Iterable<K> get keys sync* {
+    for (var i = 1; i < _chainKey.length; i++) {
+      final k = _chainKey[i];
+      if (k != null) yield k;
+    }
+  }
+
+  @override
+  Iterable<V> get values sync* {
+    for (var i = 1; i < _chainVal.length; i++) {
+      final v = _chainVal[i];
+      if (v != null) yield v;
+    }
+  }
+
+  @override
+  Iterable<MapEntry<K, V>> get entries sync* {
+    for (var i = 1; i < _chainKey.length; i++) {
+      final k = _chainKey[i];
+      final v = _chainVal[i];
+      if (k != null && v != null) {
+        yield MapEntry(k, v);
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swiss_knife
 description: Dart Useful Tools - collections, math, date, uri, json, events, resources, regexp, etc...
-version: 3.3.4
+version: 3.3.5
 homepage: https://github.com/gmpassos/swiss_knife
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   lints: ^5.1.1
   test: ^1.29.0
-  dependency_validator: ^5.0.3
+  dependency_validator: ^5.0.4
   collection: ^1.19.1
   coverage: ^1.15.0
 

--- a/test/swiss_knife_flat_hash_map.dart
+++ b/test/swiss_knife_flat_hash_map.dart
@@ -1,0 +1,443 @@
+import 'package:swiss_knife/src/flat_hash_map.dart';
+import 'package:test/test.dart';
+
+class Key {
+  final int id;
+  final int hash;
+
+  Key(this.id, this.hash);
+
+  @override
+  int get hashCode => hash;
+
+  @override
+  bool operator ==(Object other) => other is Key && other.id == id;
+}
+
+void main() {
+  group('FlatHashMap basic behavior', () {
+    test('initial state', () {
+      final map = FlatHashMap<int, String>();
+      expect(map.isEmpty, isTrue);
+      expect(map.length, 0);
+    });
+
+    test('put and get', () {
+      final map = FlatHashMap<int, String>();
+      map[1] = 'a';
+      map[2] = 'b';
+
+      expect(map.length, 2);
+      expect(map[1], 'a');
+      expect(map[2], 'b');
+      expect(map[3], isNull);
+    });
+
+    test('overwrite value returns previous', () {
+      final map = FlatHashMap<int, String>();
+      expect(map.put(1, 'a'), isNull);
+      expect(map.put(1, 'b'), 'a');
+      expect(map[1], 'b');
+      expect(map.length, 1);
+    });
+
+    test('containsKey and containsValue', () {
+      final map = FlatHashMap<int, String>();
+      map[1] = 'x';
+
+      expect(map.containsKey(1), isTrue);
+      expect(map.containsKey(2), isFalse);
+      expect(map.containsValue('x'), isTrue);
+      expect(map.containsValue('y'), isFalse);
+    });
+
+    test('remove existing and missing key', () {
+      final map = FlatHashMap<int, String>();
+      map[1] = 'a';
+      map[2] = 'b';
+
+      expect(map.remove(1), 'a');
+      expect(map.remove(1), isNull);
+      expect(map.containsKey(1), isFalse);
+      expect(map.length, 1);
+    });
+
+    test('FlatHashMap preserves key insertion order', () {
+      final map = FlatHashMap<int, String>();
+
+      map[3] = 'c';
+      map[1] = 'a';
+      map[4] = 'd';
+      map[2] = 'b';
+
+      final keys = map.keys.toList();
+      final values = map.values.toList();
+
+      expect(keys, equals([3, 1, 4, 2]));
+      expect(values, equals(['c', 'a', 'd', 'b']));
+    });
+
+    test('FlatHashMap preserves insertion order with many entries', () {
+      final map = FlatHashMap<int, int>();
+
+      const total = 10_000;
+
+      // Insert in non-sorted, deterministic order
+      for (var i = 0; i < total; i++) {
+        final key = (i * 37) % total; // permutation
+        map[key] = i;
+      }
+
+      expect(map.length, total);
+
+      final keys = map.keys.toList();
+      final values = map.values.toList();
+
+      // Rebuild expected insertion order
+      final expectedKeys = <int>[];
+      final expectedValues = <int>[];
+
+      for (var i = 0; i < total; i++) {
+        final key = (i * 37) % total;
+        expectedKeys.add(key);
+        expectedValues.add(i);
+      }
+
+      expect(keys, equals(expectedKeys));
+      expect(values, equals(expectedValues));
+    });
+  });
+
+  group('Collision handling', () {
+    test('keys with same hash but different equality', () {
+      final map = FlatHashMap<Key, String>();
+      final k1 = Key(1, 42);
+      final k2 = Key(2, 42);
+
+      map[k1] = 'a';
+      map[k2] = 'b';
+
+      expect(map.length, 2);
+      expect(map[k1], 'a');
+      expect(map[k2], 'b');
+    });
+
+    test('remove from collision chain', () {
+      final map = FlatHashMap<Key, int>();
+      final k1 = Key(1, 7);
+      final k2 = Key(2, 7);
+      final k3 = Key(3, 7);
+
+      map[k1] = 1;
+      map[k2] = 2;
+      map[k3] = 3;
+
+      expect(map.remove(k2), 2);
+      expect(map[k1], 1);
+      expect(map[k3], 3);
+      expect(map.length, 2);
+    });
+  });
+
+  group('Reuse removed slots', () {
+    test('removed entries are reused', () {
+      final map = FlatHashMap<int, int>();
+
+      map[1] = 10;
+      map[2] = 20;
+      map.remove(1);
+      map[3] = 30;
+
+      expect(map.containsKey(1), isFalse);
+      expect(map[2], 20);
+      expect(map[3], 30);
+      expect(map.length, 2);
+    });
+  });
+
+  group('Rehashing', () {
+    test('rehash preserves all entries', () {
+      final map = FlatHashMap<int, int>();
+
+      for (var i = 0; i < 100; i++) {
+        map[i] = i * 10;
+      }
+
+      expect(map.length, 100);
+      for (var i = 0; i < 100; i++) {
+        expect(map[i], i * 10);
+      }
+    });
+  });
+
+  group('Iteration and clear', () {
+    test('keys, values, entries', () {
+      final map = FlatHashMap<int, String>();
+      map[1] = 'a';
+      map[2] = 'b';
+
+      expect(map.keys.toSet(), {1, 2});
+      expect(map.values.toSet(), {'a', 'b'});
+      expect(
+        map.entries.map((e) => '${e.key}:${e.value}').toSet(),
+        {'1:a', '2:b'},
+      );
+    });
+
+    test('clear resets map', () {
+      final map = FlatHashMap<int, String>();
+      map[1] = 'x';
+      map.clear();
+
+      expect(map.isEmpty, isTrue);
+      expect(map.length, 0);
+      expect(map.containsKey(1), isFalse);
+    });
+  });
+
+  group('Edge cases and invariants', () {
+    test('null key behavior', () {
+      final map = FlatHashMap<int, String>();
+      expect(map[null], isNull);
+      expect(map.remove(null), isNull);
+      expect(map.containsKey(null), isFalse);
+    });
+
+    test('containsValue ignores removed entries', () {
+      final map = FlatHashMap<int, String>();
+      map[1] = 'a';
+      map[2] = 'b';
+      map.remove(1);
+
+      expect(map.containsValue('a'), isFalse);
+      expect(map.containsValue('b'), isTrue);
+    });
+  });
+
+  group('Chain order and head removal', () {
+    test('remove head of collision chain', () {
+      final map = FlatHashMap<Key, int>();
+      final k1 = Key(1, 5);
+      final k2 = Key(2, 5);
+
+      map[k1] = 10;
+      map[k2] = 20;
+
+      // k2 is at head due to insertion order
+      expect(map.remove(k2), 20);
+      expect(map[k1], 10);
+      expect(map.length, 1);
+    });
+
+    test('remove tail of collision chain', () {
+      final map = FlatHashMap<Key, int>();
+      final k1 = Key(1, 9);
+      final k2 = Key(2, 9);
+      final k3 = Key(3, 9);
+
+      map[k1] = 1;
+      map[k2] = 2;
+      map[k3] = 3;
+
+      expect(map.remove(k1), 1);
+      expect(map[k2], 2);
+      expect(map[k3], 3);
+      expect(map.length, 2);
+    });
+  });
+
+  group('Rehash boundaries', () {
+    test('no rehash below threshold', () {
+      final map = FlatHashMap<int, int>();
+      for (var i = 0; i < 79; i++) {
+        map[i] = i;
+      }
+
+      expect(map.length, 79);
+      for (var i = 0; i < 79; i++) {
+        expect(map[i], i);
+      }
+    });
+
+    test('multiple rehash cycles preserve correctness', () {
+      final map = FlatHashMap<int, int>();
+
+      for (var round = 0; round < 3; round++) {
+        for (var i = 0; i < 120; i++) {
+          map[i + round * 1000] = i;
+        }
+      }
+
+      expect(map.length, 360);
+      expect(map[0], 0);
+      expect(map[1000], 0);
+      expect(map[2000], 0);
+    });
+  });
+
+  group('Iteration consistency after mutations', () {
+    test('iteration after removals and inserts', () {
+      final map = FlatHashMap<int, int>();
+      map[1] = 1;
+      map[2] = 2;
+      map[3] = 3;
+
+      map.remove(2);
+      map[4] = 4;
+
+      expect(map.keys.toSet(), {1, 3, 4});
+      expect(map.values.toSet(), {1, 3, 4});
+    });
+
+    test('entries reflect latest values only', () {
+      final map = FlatHashMap<int, int>();
+      map[1] = 10;
+      map[1] = 20;
+
+      final entries = map.entries.toList();
+      expect(entries.length, 1);
+      expect(entries.single.key, 1);
+      expect(entries.single.value, 20);
+    });
+  });
+
+  group('Clear and reuse after clear', () {
+    test('put works correctly after clear', () {
+      final map = FlatHashMap<int, int>();
+      map[1] = 1;
+      map.clear();
+      map[2] = 2;
+
+      expect(map.length, 1);
+      expect(map[2], 2);
+      expect(map.containsKey(1), isFalse);
+    });
+  });
+
+  group('Rehash behavior (forced and structural)', () {
+    test('rehash changes bucket distribution but keeps lookup correct', () {
+      final map = FlatHashMap<int, int>();
+
+      // Force rehash: threshold is groups * 10 = 80
+      for (var i = 0; i < 81; i++) {
+        map[i] = i * 2;
+      }
+
+      expect(map.length, 81);
+
+      for (var i = 0; i < 81; i++) {
+        expect(map[i], i * 2);
+      }
+    });
+
+    test('rehash with heavy collisions', () {
+      final map = FlatHashMap<Key, int>();
+
+      // All keys collide initially
+      for (var i = 0; i < 90; i++) {
+        map[Key(i, 1)] = i;
+      }
+
+      expect(map.length, 90);
+
+      for (var i = 0; i < 90; i++) {
+        expect(map[Key(i, 1)], i);
+      }
+    });
+
+    test('rehash preserves chain integrity after removals', () {
+      final map = FlatHashMap<Key, int>();
+
+      for (var i = 0; i < 85; i++) {
+        map[Key(i, i % 3)] = i;
+      }
+
+      // Remove some entries before and after rehash
+      for (var i = 0; i < 85; i += 5) {
+        expect(map.remove(Key(i, i % 3)), i);
+      }
+
+      for (var i = 0; i < 85; i++) {
+        final v = map[Key(i, i % 3)];
+        if (i % 5 == 0) {
+          expect(v, isNull);
+        } else {
+          expect(v, i);
+        }
+      }
+    });
+
+    test('rehash followed by further inserts', () {
+      final map = FlatHashMap<int, int>();
+
+      for (var i = 0; i < 100; i++) {
+        map[i] = i;
+      }
+
+      for (var i = 100; i < 150; i++) {
+        map[i] = i * 3;
+      }
+
+      expect(map.length, 150);
+      expect(map[0], 0);
+      expect(map[149], 447);
+    });
+  });
+
+  group('FlatHashMap capacity bits', () {
+    test('grows to 16-bit capacity (Uint16List)', () {
+      final map = FlatHashMap<int, int>();
+
+      expect(map.capacityBits, 8);
+      expect(map.length, 0);
+
+      for (var i = 0; i < 100; i++) {
+        map[i] = i;
+      }
+
+      expect(map.capacityBits, 8);
+      expect(map.length, 100);
+
+      // Grow beyond 0xFF (255) entries
+      for (var i = 100; i < 300; i++) {
+        map[i] = i;
+      }
+
+      expect(map.capacityBits, 16);
+      expect(map.length, 300);
+
+      // Sanity check correctness
+      for (var i = 0; i < 300; i++) {
+        expect(map[i], i);
+      }
+    });
+
+    test('grows to 32-bit capacity (Uint32List)', () {
+      final map = FlatHashMap<int, int>();
+
+      expect(map.capacityBits, 8);
+      expect(map.length, 0);
+
+      // Grow beyond 0xFF (255) entries
+      for (var i = 0; i < 1000; i++) {
+        map[i] = i;
+      }
+
+      expect(map.capacityBits, 16);
+      expect(map.length, 1000);
+
+      // Grow beyond 0xFFFF (65535) entries
+      for (var i = 1000; i < 70000; i++) {
+        map[i] = i;
+      }
+
+      expect(map.capacityBits, 32);
+      expect(map.length, 70000);
+
+      // Spot-check correctness
+      for (var i = 0; i < 1000; i += 137) {
+        expect(map[i], i);
+      }
+    });
+  });
+}


### PR DESCRIPTION
- `EventStream`:
  - Changed `_controller` field to nullable `_controllerObj` and lazily initialized it.
  - Changed `_stream` field to nullable `_streamObj` and lazily initialized it as a broadcast stream.
  - Updated `add` and `addError` methods to check `isUsed` (based on `_streamObj` presence) before adding events.
  - Updated `close`, `isClosed`, and `isPaused` to handle nullable `_controllerObj`.
  - Added `isUsed` getter to indicate if the stream has been used (initialized).

- `pubspec.yaml`:
  - Updated `dependency_validator` version from `^5.0.3` to `^5.0.4`.