### PR TITLE
v3.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `weak_map.dart`:
   - Refactored internal entry classes to support lazy weak references:
     - Added `_EntryLazyRef`, `_EntryLazyRef1`, `_EntryLazyRef2`, `_EntryLazyRefValue`.
+  - `WeakKeyMap`: include _autoPurge in isAutoPurgeRequired and centralize auto-purge check.
   - Added `LazyWeakKeyMap` subclass using lazy weak references for keys.
   - Added `DualLazyWeakMap` subclass using lazy weak references for keys and values.
   - Added factory constructors `WeakKeyMap.configured` and `DualWeakMap.configured` to create lazy weak reference variants.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## 3.3.13
+
+- `TreeReferenceMap`:
+  - Replaced `_purged` field type from `DualWeakMap` to `DualLazyWeakMap`.
+  - Use global `LazyWeakReferenceManagerByType` to create `DualLazyWeakMap` instances for purged entries.
+
+- `ExpandoWithFinalizer`:
+  - Refactored to extend generic `WithFinalizer` base class.
+  - Introduced strongly typed `FinalizerValueWrapper` abstraction and concrete implementations:
+    - `SimpleFinalizerWrapper`, `SimpleFinalizerWrapperDebug`
+    - `ExpandoValueWrapper`, `ExpandoValueWrapperDebug`
+  - Added `AttachOnlyFinalizer` class for write-only finalizer usage.
+  - Added `debug` mode to retain weak references to keys for inspection.
+  - Improved finalizer attach/detach logic and wrapper management.
+
+- `lazy_weak_reference.dart`:
+  - Added `GenericReference` interface for strong/weak reference abstraction.
+  - Added `LazyWeakReferenceManagerByType` singleton managing per-type `LazyWeakReferenceManager` instances.
+  - Added `toString` and `compareTo` improvements to `LazyWeakReference`.
+  - Added `LazyWeakReferenceManagerByType` class for centralized management.
+  - Added `toString` override to `LazyWeakReferenceManager`.
+
+- `weak_map.dart`:
+  - Refactored internal entry classes to support lazy weak references:
+    - Added `_EntryLazyRef`, `_EntryLazyRef1`, `_EntryLazyRef2`, `_EntryLazyRefValue`.
+  - Added `LazyWeakKeyMap` subclass using lazy weak references for keys.
+  - Added `DualLazyWeakMap` subclass using lazy weak references for keys and values.
+  - Added factory constructors `WeakKeyMap.configured` and `DualWeakMap.configured` to create lazy weak reference variants.
+  - Added `removeWhereKey` extension method on `Map` and `WeakKeyMap`.
+  - Updated purge logic to use `removeWhereKey`.
+  - Updated `DualWeakMap` to optionally use lazy weak references for keys and values.
+
+- `resource.dart`:
+  - Changed `ResourceContentCache` to use private `_onLoadEventStream` instead of public `onLoad` field.
+  - Updated `ResourceContent` to lazily initialize `_onLoadEventStream` and use it internally.
+  - Changed event notification to use `_onLoadEventStream?.add` instead of `onLoad.add`.
+
 ## 3.3.12
 
 - `LazyWeakReference`:

--- a/lib/src/collections.dart
+++ b/lib/src/collections.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:math' as dart_math;
 
 import 'date.dart';
+import 'lazy_weak_reference.dart';
 import 'math.dart';
 import 'utils.dart';
 import 'weak_map.dart';
@@ -2713,7 +2714,7 @@ class TreeReferenceMap<K extends Object, V extends Object>
   bool isChildOf(K? parent, K? child, bool deep) =>
       parent != null && child != null && childChecker!(parent, child, deep);
 
-  DualWeakMap<K, MapEntry<DateTime, V>>? _purged;
+  DualLazyWeakMap<K, MapEntry<DateTime, V>>? _purged;
 
   /// Returns the purged entries length. Only relevant if [keepPurgedEntries] is true.
   int get purgedLength => _purged != null ? _purged!.length : 0;
@@ -2727,6 +2728,9 @@ class TreeReferenceMap<K extends Object, V extends Object>
     _purged = null;
     _expireCache();
   }
+
+  static final _lazyWeakReferenceManagerByType =
+      LazyWeakReferenceManagerByType.global;
 
   int _purgedEntriesCount = 0;
 
@@ -2751,7 +2755,13 @@ class TreeReferenceMap<K extends Object, V extends Object>
       var invalidKeys = this.invalidKeys;
       if (invalidKeys.isEmpty) return this;
 
-      var purged = _purged ?? DualWeakMap(autoPurge: false);
+      final purged = _purged ??
+          DualLazyWeakMap(
+            _lazyWeakReferenceManagerByType.get(),
+            _lazyWeakReferenceManagerByType.get(),
+            autoPurge: false,
+          );
+
       _purged = purged;
 
       for (var k in invalidKeys) {

--- a/lib/src/expando_with_finalizer.dart
+++ b/lib/src/expando_with_finalizer.dart
@@ -1,19 +1,228 @@
-/// Small wrapper used as the Expando payload.
-class _ExpandoBox<V> {
-  final V value;
-
-  _ExpandoBox(this.value);
+/// A strongly typed wrapper used as a finalization token.
+///
+/// Implementations encapsulate a non-null [value] that will be delivered
+/// to user code when the associated key becomes unreachable and is
+/// garbage-collected.
+///
+/// This indirection allows attaching structured metadata to a
+/// [Finalizer] while keeping the actual value strongly typed.
+abstract class FinalizerValueWrapper<V extends Object> {
+  /// The wrapped value associated with the finalizer.
+  ///
+  /// Must always return a non-null instance.
+  V get value;
 }
 
-/// Callback executed with the associated value when the key becomes
-/// unreachable and is garbage-collected.
-typedef ExpandoFinalizer<V> = void Function(V value);
+/// Simple concrete implementation of [FinalizerValueWrapper].
+///
+/// Holds a strong reference to [value] to be delivered on finalization.
+class SimpleFinalizerWrapper<V extends Object>
+    extends FinalizerValueWrapper<V> {
+  @override
+  final V value;
+
+  SimpleFinalizerWrapper(this.value);
+}
+
+/// Debug variant of [SimpleFinalizerWrapper].
+///
+/// In addition to the wrapped value, it keeps a weak reference to the
+/// associated [key] for inspection. The key is stored in [_key] as a
+/// [WeakReference], so it does not prevent garbage collection.
+///
+/// Intended for memory leak analysis and lifecycle debugging.
+class SimpleFinalizerWrapperDebug<K extends Object, V extends Object>
+    extends SimpleFinalizerWrapper<V> {
+  /// Weak reference to the associated key (debug only).
+  final WeakReference<K> _key;
+
+  K? get key => _key.target;
+
+  SimpleFinalizerWrapperDebug(K key, super.value) : _key = WeakReference(key);
+}
+
+/// Signature for a callback invoked when a key associated with a
+/// finalizer becomes unreachable.
+///
+/// The provided [value] corresponds to the value previously associated
+/// with the collected key.
+typedef FinalizerCallback<V> = void Function(V value);
+
+/// Base class for managing key → value associations backed by a [Finalizer].
+///
+/// A value is weakly associated with a key. When the key becomes
+/// unreachable and is garbage-collected, the provided [onFinalize]
+/// callback is invoked with the associated value.
+///
+/// Implementations are responsible for:
+/// - Storing and retrieving wrappers via [createWrapper] and [getWrapper].
+/// - Maintaining any required internal key → wrapper mapping.
+///
+/// The finalizer is automatically attached and detached as associations
+/// are added, replaced, or manually removed.
+abstract class WithFinalizer<K extends Object, V extends Object,
+    W extends FinalizerValueWrapper<V>> {
+  /// User-provided callback invoked when a key is garbage-collected.
+  final FinalizerCallback<V> onFinalize;
+
+  WithFinalizer(this.onFinalize);
+
+  /// Internal [Finalizer] responsible for tracking key reachability.
+  ///
+  /// When a key is collected, `_onFinalize` receives the associated
+  /// wrapper token.
+  late final Finalizer<W> _finalizer = Finalizer<W>(_onFinalize);
+
+  /// Internal bridge between the Dart [Finalizer] and user code.
+  ///
+  /// Extracts the wrapped value and forwards it to [onFinalize].
+  /// Any exception thrown by user code is routed to [onFinalizeError].
+  void _onFinalize(W wrapper) {
+    try {
+      onFinalize(wrapper.value);
+    } catch (error, stackTrace) {
+      onFinalizeError(error, stackTrace);
+    }
+  }
+
+  /// Called when [onFinalize] throws.
+  ///
+  /// Default implementation is a no-op. Subclasses may override to log
+  /// or report errors.
+  void onFinalizeError(Object error, StackTrace stackTrace) {}
+
+  /// Associates [value] with [key], replacing any existing association.
+  ///
+  /// If a wrapper is already associated with [key]:
+  /// - If its value is `identical` to [value], nothing is changed.
+  /// - Otherwise, the previous finalization is detached before
+  ///   attaching the new association.
+  ///
+  /// When [key] becomes unreachable and is garbage-collected,
+  /// [onFinalize] is invoked with the associated [value].
+  void put(K key, V value) {
+    final previousWrapper = getWrapper(key);
+
+    if (previousWrapper != null) {
+      if (identical(previousWrapper.value, value)) {
+        // Avoid unnecessary detach/attach when nothing changed.
+        return;
+      }
+
+      // Cancel pending finalization for the previous association.
+      _finalizer.detach(previousWrapper);
+    }
+
+    final wrapper = createWrapper(key, value);
+
+    // Attach finalization to the key lifecycle.
+    //
+    // When [key] is garbage-collected, `_onFinalize(wrapper)` will run.
+    // The wrapper itself is used as the detach token, allowing explicit
+    // cancellation via `_finalizer.detach(wrapper)`.
+    _finalizer.attach(key, wrapper, detach: wrapper);
+  }
+
+  /// Creates a wrapper for the given [key] and [value].
+  ///
+  /// Implementations typically store the wrapper in an internal
+  /// key → wrapper structure before returning it.
+  W createWrapper(K key, V value);
+
+  /// Returns the wrapper currently associated with [key], or `null`
+  /// if no association exists.
+  W? getWrapper(K key);
+
+  /// Removes the association for [key], if present.
+  ///
+  /// Detaches the wrapper from the internal [Finalizer] to prevent
+  /// the callback from firing in the future.
+  ///
+  /// Returns the previously associated value, or `null` if none existed.
+  V? remove(K key) {
+    final wrapper = getWrapper(key);
+    if (wrapper != null) {
+      _finalizer.detach(wrapper);
+      return wrapper.value;
+    }
+    return null;
+  }
+}
+
+/// A write-only [WithFinalizer] implementation.
+///
+/// Associates values with keys solely for finalization purposes.
+/// This class does **not** store, expose, or allow removal of
+/// key–value associations.
+///
+/// When a [key] becomes unreachable and is garbage-collected,
+/// the provided [onFinalize] callback is invoked with the
+/// associated value.
+///
+/// Any attempt to retrieve or manually remove an association
+/// results in [UnsupportedError].
+class AttachOnlyFinalizer<K extends Object, V extends Object>
+    extends WithFinalizer<K, V, SimpleFinalizerWrapper<V>> {
+  /// Enables debug mode.
+  ///
+  /// When `true`, created wrappers retain a weak reference to the
+  /// associated key, allowing inspection for memory leak analysis.
+  /// When `false`, a minimal wrapper is used.
+  final bool debug;
+
+  /// Creates an attach-only finalizer.
+  ///
+  /// The [onFinalize] callback is invoked when a key becomes
+  /// unreachable and is garbage-collected.
+  ///
+  /// If [debug] is enabled, debug wrappers are created to allow
+  /// key inspection during lifecycle analysis.
+  AttachOnlyFinalizer(super.onFinalize, {this.debug = false});
+
+  @override
+  SimpleFinalizerWrapper<V> createWrapper(K key, V value) => debug
+      ? SimpleFinalizerWrapperDebug(key, value)
+      : SimpleFinalizerWrapper(value);
+
+  @override
+  SimpleFinalizerWrapper<V>? getWrapper(K key) => null;
+
+  @override
+  Never remove(K key) => throw UnsupportedError("Can't remove keys!");
+}
+
+/// Concrete [FinalizerValueWrapper] used by [ExpandoWithFinalizer].
+///
+/// Stores a strongly referenced [value] delivered to the finalizer callback.
+class ExpandoValueWrapper<V extends Object> extends FinalizerValueWrapper<V> {
+  @override
+  final V value;
+
+  ExpandoValueWrapper(this.value);
+}
+
+/// Debug variant of [ExpandoValueWrapper].
+///
+/// Stores a weak reference to the associated `key` in the [_key] field
+/// for inspection, without preventing it from being garbage-collected.
+///
+/// Useful for memory leak inspection and tracking unexpected
+/// object retention.
+class ExpandoValueWrapperDebug<K extends Object, V extends Object>
+    extends ExpandoValueWrapper<V> {
+  /// Weak reference to the associated key (debug only).
+  final WeakReference<K> _key;
+
+  K? get key => _key.target;
+
+  ExpandoValueWrapperDebug(K key, super.value) : _key = WeakReference(key);
+}
 
 /// A weak key → strong value association similar to [Expando], but with a
 /// finalization callback.
 ///
 /// When a [key] becomes unreachable and is garbage-collected, the provided
-/// [onFinalize] ([ExpandoFinalizer]) is invoked with the last associated value.
+/// [onFinalize] ([FinalizerCallback]) is invoked with the last associated value.
 ///
 /// The value remains alive while associated with the key. Replacing or removing
 /// the value cancels the pending finalization for the previous association.
@@ -22,52 +231,48 @@ typedef ExpandoFinalizer<V> = void Function(V value);
 /// - Cleaning native resources tied to Dart objects
 /// - Cache entries that must release external handles
 /// - Lifecycle hooks without modifying the key class
-class ExpandoWithFinalizer<K extends Object, V extends Object> {
+class ExpandoWithFinalizer<K extends Object, V extends Object>
+    extends WithFinalizer<K, V, ExpandoValueWrapper<V>> {
   /// Native Expando that weakly associates data to a key (does not prevent GC).
-  final Expando<_ExpandoBox<V>> _expando = Expando<_ExpandoBox<V>>();
+  final Expando<ExpandoValueWrapper<V>> _expando =
+      Expando<ExpandoValueWrapper<V>>();
 
-  /// User-provided finalization callback.
-  final ExpandoFinalizer<V> onFinalize;
+  /// Enables debug mode.
+  ///
+  /// When `true`, wrappers retain an additional weak reference to the
+  /// associated key, allowing inspection for memory leak analysis.
+  /// When `false`, a lighter wrapper is used.
+  final bool debug;
 
-  ExpandoWithFinalizer(this.onFinalize);
+  /// Creates an [ExpandoWithFinalizer].
+  ///
+  /// If [debug] is enabled, a debug wrapper is used to allow
+  /// key inspection during memory analysis.
+  ExpandoWithFinalizer(super.onFinalize, {this.debug = false});
 
-  /// Finalizer triggered when the associated key is garbage-collected.
-  /// It receives the attached token (_ExpandoBox) so the stored value
-  /// can be forwarded to the user callback.
-  late final Finalizer<_ExpandoBox> _finalizer =
-      Finalizer<_ExpandoBox>(_onFinalize);
-
-  // Internal bridge: unwrap the stored value and notify user code.
-  void _onFinalize(_ExpandoBox box) {
-    onFinalize(box.value);
-  }
-
-  /// Associates [value] with [key], replacing any previous value.
-  /// Cancels the previous finalization and attaches a new one.
-  /// When the key is GC-collected, [onFinalize] is called with the [value].
-  void put(K key, V value) {
-    final prevBox = _expando[key];
-    if (prevBox != null) {
-      if (identical(prevBox.value, value)) {
-        // Same object already associated → avoid detach/attach churn.
-        return;
-      }
-
-      // Cancel pending finalization for the previous value because the
-      // association is being replaced.
-      _finalizer.detach(prevBox);
-    }
-
-    final box = _ExpandoBox<V>(value);
-
+  /// Creates and stores a wrapper for the given [key] and [value].
+  ///
+  /// The wrapper type depends on [debug]:
+  /// - `false`: uses [ExpandoValueWrapper].
+  /// - `true`: uses [ExpandoValueWrapperDebug] (keeps a weak reference to [key]).
+  ///
+  /// The wrapper is weakly associated with [key] via the internal [Expando].
+  @override
+  ExpandoValueWrapper<V> createWrapper(K key, V value) {
+    final wrapper = debug
+        ? ExpandoValueWrapperDebug<K, V>(key, value)
+        : ExpandoValueWrapper<V>(value);
     // Weakly associate value with the key.
-    _expando[key] = box;
-
-    // Attach finalization to the key lifecycle.
-    // When key is GC-collected, `_onFinalize(box)` will be invoked.
-    // `detach: box` allows later manual cancellation via detach(box).
-    _finalizer.attach(key, box, detach: box);
+    _expando[key] = wrapper;
+    return wrapper;
   }
+
+  /// Returns the wrapper associated with [key], if any.
+  ///
+  /// The association is stored internally using an [Expando],
+  /// so it does not prevent [key] from being garbage-collected.
+  @override
+  ExpandoValueWrapper<V>? getWrapper(K key) => _expando[key];
 
   /// Returns associated value if the [key] is still alive.
   V? get(K key) => _expando[key]?.value;
@@ -75,15 +280,12 @@ class ExpandoWithFinalizer<K extends Object, V extends Object> {
   /// Returns whether a value is currently associated with [key].
   bool containsKey(K key) => _expando[key] != null;
 
-  /// Removes and returns the value associated with [key], if any.
-  /// Cancels the pending finalization for that association.
+  @override
   V? remove(K key) {
-    final box = _expando[key];
-    if (box != null) {
-      // Manual removal: prevent the finalizer from firing later.
-      _finalizer.detach(box);
+    var value = super.remove(key);
+    if (value != null) {
       _expando[key] = null;
-      return box.value;
+      return value;
     }
     return null;
   }

--- a/lib/src/resource.dart
+++ b/lib/src/resource.dart
@@ -37,7 +37,7 @@ class ResourceContentCache {
         var content = resourceContent._content;
 
         cached._content = content;
-        cached.onLoad.add(content);
+        cached._onLoadEventStream?.add(content);
       }
 
       return cached;
@@ -160,8 +160,10 @@ class ResourceContent {
 
   Future<String>? _readFuture;
 
+  EventStream<String?>? _onLoadEventStream;
+
   /// Notifies events when load is completed.
-  final EventStream<String?> onLoad = EventStream();
+  EventStream<String?> get onLoad => _onLoadEventStream ??= EventStream();
 
   /// Triggers content load.
   Future<void> load() async {
@@ -196,7 +198,7 @@ class ResourceContent {
     _content = content;
     _loaded = true;
     _loadError = loadError;
-    onLoad.add(content);
+    _onLoadEventStream?.add(content);
   }
 
   /// Returns [true] if loaded.

--- a/lib/src/weak_map.dart
+++ b/lib/src/weak_map.dart
@@ -469,7 +469,7 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
 
   /// Runs purge automatically if the threshold is exceeded.
   bool autoPurge() {
-    if (_autoPurge && isAutoPurgeRequired()) {
+    if (isAutoPurgeRequired()) {
       purge();
       return true;
     }
@@ -477,7 +477,8 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
   }
 
   /// Returns `true` if auto-purge should be triggered.
-  bool isAutoPurgeRequired() => _unpurgedCount >= _autoPurgeThreshold;
+  bool isAutoPurgeRequired() =>
+      _autoPurge && _unpurgedCount >= _autoPurgeThreshold;
 
   @override
   int get length {

--- a/lib/src/weak_map.dart
+++ b/lib/src/weak_map.dart
@@ -1,5 +1,7 @@
 import 'dart:collection';
 
+import 'lazy_weak_reference.dart';
+
 /// Internal map entry abstraction.
 ///
 /// Encapsulates equality and hashing semantics based on the underlying
@@ -27,24 +29,17 @@ abstract class _Entry<K extends Object, V extends Object> {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    if (other is _Entry<K, V>) {
-      if (_hashCode != other._hashCode) return false;
+    if (other is! _Entry<K, V>) return false;
 
-      final target = this.target;
-      if (target == null) return false;
+    if (_hashCode != other._hashCode) return false;
 
-      final otherTarget = other.target;
-      if (otherTarget == null) return false;
+    final target = this.target;
+    if (target == null) return false;
 
-      if (identical(target, otherTarget)) return true;
-      return target == otherTarget;
-    } else {
-      final target = this.target;
-      if (target == null) return false;
+    final otherTarget = other.target;
+    if (otherTarget == null) return false;
 
-      if (identical(target, other)) return true;
-      return target == other;
-    }
+    return target == otherTarget;
   }
 }
 
@@ -69,20 +64,16 @@ class _EntryKey<K extends Object, V extends Object> extends _Entry<K, V> {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    if (other is _Entry<K, V>) {
-      if (_hashCode != other._hashCode) return false;
+    if (other is! _Entry<K, V>) return false;
 
-      final otherTarget = other.target;
-      if (otherTarget == null) return false;
+    if (_hashCode != other._hashCode) return false;
 
-      final target = _obj;
-      if (identical(target, otherTarget)) return true;
-      return target == otherTarget;
-    } else {
-      final target = _obj;
-      if (identical(target, other)) return true;
-      return target == other;
-    }
+    final otherTarget = other.target;
+    if (otherTarget == null) return false;
+
+    final target = _obj;
+
+    return target == otherTarget;
   }
 
   @override
@@ -92,10 +83,19 @@ class _EntryKey<K extends Object, V extends Object> extends _Entry<K, V> {
 /// Base class for entries holding a weakly-referenced key.
 abstract class _EntryRef<K extends Object, V extends Object>
     extends _Entry<K, V> {
+  _EntryRef(super._hashCode);
+
+  @override
+  K? get target;
+}
+
+/// Base class for entries holding a weakly-referenced key.
+abstract class _EntryWeakRef<K extends Object, V extends Object>
+    extends _EntryRef<K, V> {
   /// Weak reference to the key.
   final WeakReference<K> _refKey;
 
-  _EntryRef(K key)
+  _EntryWeakRef(K key)
       : _refKey = WeakReference(key),
         super(key.hashCode);
 
@@ -104,10 +104,11 @@ abstract class _EntryRef<K extends Object, V extends Object>
 }
 
 /// Entry with a weak key and a strong value.
-class _EntryRef1<K extends Object, V extends Object> extends _EntryRef<K, V> {
+class _EntryWeakRef1<K extends Object, V extends Object>
+    extends _EntryWeakRef<K, V> {
   final V _value;
 
-  _EntryRef1(super.key, V value) : _value = value;
+  _EntryWeakRef1(super.key, V value) : _value = value;
 
   @override
   V get payload => _value;
@@ -115,31 +116,59 @@ class _EntryRef1<K extends Object, V extends Object> extends _EntryRef<K, V> {
 
 /// Entry with both key and value weakly referenced.
 ///
-/// The value is tracked via a paired [_EntryRefValue].
-class _EntryRef2<K extends Object, V extends Object> extends _EntryRef<K, V> {
-  late final _EntryRefValue<V, K> _valueEntry;
+/// The value is tracked via a paired [_EntryWeakRefValue].
+abstract class _EntryRef2<K extends Object, V extends Object>
+    implements _EntryRef<K, V> {
+  _EntryRefValue<V, K> get _valueEntry;
 
-  _EntryRef2(super.key, V value) {
-    _valueEntry = _EntryRefValue<V, K>(this, value);
+  @override
+  V? get payload;
+}
+
+/// Entry with both key and value weakly referenced.
+///
+/// The value is tracked via a paired [_EntryWeakRefValue].
+class _EntryWeakRef2<K extends Object, V extends Object>
+    extends _EntryWeakRef<K, V> implements _EntryRef2<K, V> {
+  @override
+  late final _EntryWeakRefValue<V, K> _valueEntry;
+
+  _EntryWeakRef2(super.key, V value) {
+    _valueEntry = _EntryWeakRefValue<V, K>(this, value);
   }
 
   @override
   V? get payload => _valueEntry._refValue.target;
 }
 
-/// Weak-value entry paired with a [_EntryRef2] key entry.
-class _EntryRefValue<V extends Object, K extends Object> extends _Entry<V, K> {
-  final _EntryRef2<K, V> _keyEntry;
+/// Weak-value entry paired with a [_EntryWeakRef2] key entry.
+abstract class _EntryRefValue<V extends Object, K extends Object>
+    implements _Entry<V, K> {
+  /// Back-reference to the owning key entry.
+  _EntryRef2<K, V> get keyEntry;
+
+  @override
+  V? get target;
+
+  @override
+  K? get payload;
+}
+
+/// Weak-value entry paired with a [_EntryWeakRef2] key entry.
+class _EntryWeakRefValue<V extends Object, K extends Object>
+    extends _Entry<V, K> implements _EntryRefValue<V, K> {
+  final _EntryWeakRef2<K, V> _keyEntry;
 
   /// Weak reference to the value.
   final WeakReference<V> _refValue;
 
-  _EntryRefValue(this._keyEntry, V value)
+  _EntryWeakRefValue(this._keyEntry, V value)
       : _refValue = WeakReference(value),
         super(value.hashCode);
 
   /// Back-reference to the owning key entry.
-  _EntryRef2<K, V> get keyEntry => _keyEntry;
+  @override
+  _EntryWeakRef2<K, V> get keyEntry => _keyEntry;
 
   @override
   V? get target => _refValue.target;
@@ -147,6 +176,96 @@ class _EntryRefValue<V extends Object, K extends Object> extends _Entry<V, K> {
   @override
   K? get payload => _keyEntry._refKey.target;
 }
+
+/// Base class for entries holding a [LazyWeakReference] key.
+abstract class _EntryLazyRef<K extends Object, V extends Object>
+    extends _EntryRef<K, V> {
+  /// Weak reference to the key.
+  final LazyWeakReference<K> _refKey;
+
+  _EntryLazyRef(K key, LazyWeakReferenceManager<K> keyRefManager)
+      : _refKey = keyRefManager.strong(key),
+        super(key.hashCode);
+
+  @override
+  K? get target => _refKey.target;
+}
+
+/// Entry with a lazy weak key and a strong value.
+class _EntryLazyRef1<K extends Object, V extends Object>
+    extends _EntryLazyRef<K, V> {
+  final V _value;
+
+  _EntryLazyRef1(super.key, super.keyRefManager, V value) : _value = value;
+
+  @override
+  V get payload => _value;
+}
+
+/// Entry with both key and value lazy weakly referenced.
+///
+/// The value is tracked via a paired [_EntryWeakRefValue].
+class _EntryLazyRef2<K extends Object, V extends Object>
+    extends _EntryLazyRef<K, V> implements _EntryRef2<K, V> {
+  @override
+  late final _EntryLazyRefValue<V, K> _valueEntry;
+
+  _EntryLazyRef2(super.key, super.keyRefManager, V value,
+      LazyWeakReferenceManager<V> valueRefManager) {
+    _valueEntry = _EntryLazyRefValue<V, K>(this, value, valueRefManager);
+  }
+
+  @override
+  V? get payload => _valueEntry._refValue.target;
+}
+
+/// Weak-value entry paired with a [_EntryWeakRef2] key entry.
+class _EntryLazyRefValue<V extends Object, K extends Object>
+    extends _Entry<V, K> implements _EntryRefValue<V, K> {
+  final _EntryLazyRef2<K, V> _keyEntry;
+
+  /// Weak reference to the value.
+  final LazyWeakReference<V> _refValue;
+
+  _EntryLazyRefValue(
+      this._keyEntry, V value, LazyWeakReferenceManager<V> valueRefManager)
+      : _refValue = valueRefManager.strong(value),
+        super(value.hashCode);
+
+  /// Back-reference to the owning key entry.
+  @override
+  _EntryLazyRef2<K, V> get keyEntry => _keyEntry;
+
+  @override
+  V? get target => _refValue.target;
+
+  @override
+  K? get payload => _keyEntry._refKey.target;
+}
+
+class LazyWeakKeyMap<K extends Object, V extends Object>
+    extends WeakKeyMap<K, V> {
+  final LazyWeakReferenceManager<K>? _keyLazyRefManager;
+
+  LazyWeakKeyMap(
+    LazyWeakReferenceManager<K>? keyLazyRefManager, {
+    super.autoPurge,
+    super.autoPurgeThreshold,
+    super.onPurgedValues,
+  }) : _keyLazyRefManager = keyLazyRefManager;
+
+  @override
+  _EntryRef<K, V> _createEntry(key, value) {
+    final keyLazyRefManager = _keyLazyRefManager;
+    if (keyLazyRefManager != null) {
+      return _EntryLazyRef1<K, V>(key, keyLazyRefManager, value);
+    } else {
+      return _EntryWeakRef1<K, V>(key, value);
+    }
+  }
+}
+
+typedef OnPurgedValues<V> = void Function(List<V> purgedValues);
 
 /// A [Map] with weakly-referenced keys.
 ///
@@ -168,7 +287,7 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
   static const defaultAutoPurgeThreshold = 100;
 
   /// Optional callback invoked with values removed during purge.
-  final void Function(List<V> purgedValues)? onPurgedValues;
+  final OnPurgedValues<V>? onPurgedValues;
 
   WeakKeyMap(
       {bool autoPurge = true,
@@ -177,6 +296,22 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
       : _autoPurge = autoPurge,
         _autoPurgeThreshold = _normalizeAutoPurgeThreshold(autoPurgeThreshold),
         super();
+
+  factory WeakKeyMap.configured(
+      {bool autoPurge = true,
+      int autoPurgeThreshold = defaultAutoPurgeThreshold,
+      OnPurgedValues<V>? onPurgedValues,
+      LazyWeakReferenceManager<K>? keyLazyRefManager}) {
+    return keyLazyRefManager != null
+        ? LazyWeakKeyMap(keyLazyRefManager,
+            autoPurge: autoPurge,
+            autoPurgeThreshold: autoPurgeThreshold,
+            onPurgedValues: onPurgedValues)
+        : WeakKeyMap(
+            autoPurge: autoPurge,
+            autoPurgeThreshold: autoPurgeThreshold,
+            onPurgedValues: onPurgedValues);
+  }
 
   static int _normalizeAutoPurgeThreshold(int autoPurgeThreshold) =>
       autoPurgeThreshold >= 1 ? autoPurgeThreshold : defaultAutoPurgeThreshold;
@@ -283,7 +418,7 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
   }
 
   /// Factory for creating entry representations.
-  _EntryRef<K, V> _createEntry(key, value) => _EntryRef1<K, V>(key, value);
+  _EntryRef<K, V> _createEntry(key, value) => _EntryWeakRef1<K, V>(key, value);
 
   /// Hook invoked after inserting an entry.
   void _onPutEntry(_EntryRef<K, V> e, V value) {}
@@ -302,10 +437,10 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
 
     var purgedValues = <V>[];
 
-    _map.removeWhere((key, value) {
-      if (value.target == null) {
+    _map.removeWhereKey((key) {
+      if (key.target == null) {
         if (onPurgedValues != null) {
-          var v = value.payload;
+          var v = key.payload;
           if (v != null) {
             purgedValues.add(v);
           }
@@ -501,6 +636,22 @@ class WeakKeyMap<K extends Object, V extends Object> extends MapBase<K, V> {
       _onRemoveEntry(k);
     }
   }
+
+  void removeWhereKey(bool Function(K key) test) {
+    var del = <_EntryRef<K, V>>[];
+
+    for (var k in _map.keys) {
+      var target = k.target;
+      if (target == null || test(target)) {
+        del.add(k);
+      }
+    }
+
+    for (var k in del) {
+      _map.remove(k);
+      _onRemoveEntry(k);
+    }
+  }
 }
 
 /// Iterable adapter for [WeakKeyMap].
@@ -580,6 +731,34 @@ class _WeakMapIterator<K extends Object, V extends Object, T>
   }
 }
 
+class DualLazyWeakMap<K extends Object, V extends Object>
+    extends DualWeakMap<K, V> {
+  final LazyWeakReferenceManager<K>? _keyLazyRefManager;
+  final LazyWeakReferenceManager<V>? _valueLazyRefManager;
+
+  DualLazyWeakMap(
+    LazyWeakReferenceManager<K> keyLazyRefManager,
+    LazyWeakReferenceManager<V> valueLazyRefManager, {
+    super.autoPurge,
+    super.autoPurgeThreshold,
+    super.onPurgedValues,
+  })  : _keyLazyRefManager = keyLazyRefManager,
+        _valueLazyRefManager = valueLazyRefManager;
+
+  @override
+  _EntryRef<K, V> _createEntry(key, value) {
+    final keyLazyRefManager = _keyLazyRefManager;
+    final valueLazyRefManager = _valueLazyRefManager;
+
+    if (keyLazyRefManager != null && valueLazyRefManager != null) {
+      return _EntryLazyRef2<K, V>(
+          key, keyLazyRefManager, value, valueLazyRefManager);
+    } else {
+      return _EntryWeakRef2<K, V>(key, value);
+    }
+  }
+}
+
 /// A [Map] with both keys and values weakly referenced.
 ///
 /// Unlike [Expando], this is a complete [Map] implementation, supporting the
@@ -597,8 +776,29 @@ class DualWeakMap<K extends Object, V extends Object> extends WeakKeyMap<K, V> {
   DualWeakMap(
       {super.autoPurge, super.autoPurgeThreshold, super.onPurgedValues});
 
+  factory DualWeakMap.configured({
+    bool autoPurge = true,
+    int autoPurgeThreshold = WeakKeyMap.defaultAutoPurgeThreshold,
+    OnPurgedValues<V>? onPurgedValues,
+    LazyWeakReferenceManager<K>? keyLazyRefManager,
+    LazyWeakReferenceManager<V>? valueLazyRefManager,
+  }) {
+    return keyLazyRefManager != null && valueLazyRefManager != null
+        ? DualLazyWeakMap(
+            keyLazyRefManager,
+            valueLazyRefManager,
+            autoPurge: autoPurge,
+            autoPurgeThreshold: autoPurgeThreshold,
+            onPurgedValues: onPurgedValues,
+          )
+        : DualWeakMap(
+            autoPurge: autoPurge,
+            autoPurgeThreshold: autoPurgeThreshold,
+            onPurgedValues: onPurgedValues);
+  }
+
   @override
-  _EntryRef<K, V> _createEntry(key, value) => _EntryRef2<K, V>(key, value);
+  _EntryRef<K, V> _createEntry(key, value) => _EntryWeakRef2<K, V>(key, value);
 
   /// Returns the key associated with a given value, if still alive.
   K? getKeyFromValue(Object? value) {
@@ -745,4 +945,16 @@ class SwappedDualWeakMap<V extends Object, K extends Object>
 
   @override
   void clear() => _dualWeakMap.clear();
+}
+
+extension _MapExtension<K, V> on Map<K, V> {
+  void removeWhereKey(bool Function(K key) test) {
+    var keysToRemove = <K>[];
+    for (var key in keys) {
+      if (test(key)) keysToRemove.add(key);
+    }
+    for (var key in keysToRemove) {
+      remove(key);
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swiss_knife
 description: Dart Useful Tools - collections, math, date, uri, json, events, resources, regexp, etc...
-version: 3.3.12
+version: 3.3.13
 homepage: https://github.com/gmpassos/swiss_knife
 
 environment:

--- a/test/swiss_knife_expando_with_finalizer_test.dart
+++ b/test/swiss_knife_expando_with_finalizer_test.dart
@@ -459,6 +459,7 @@ void main() {
       await _waitUntil(() => finalized.length == 2);
 
       expect(finalized.toSet(), {'a', 'b'});
+      expect(f, isNotNull);
     });
   });
 }

--- a/test/swiss_knife_expando_with_finalizer_test.dart
+++ b/test/swiss_knife_expando_with_finalizer_test.dart
@@ -323,7 +323,8 @@ void main() {
 
       createKey();
 
-      await _waitUntil(() => finalized.isNotEmpty);
+      await _waitUntil(
+          timeout: Duration(seconds: 30), () => finalized.isNotEmpty);
 
       expect(finalized, ['value']);
     });

--- a/test/swiss_knife_expando_with_finalizer_test.dart
+++ b/test/swiss_knife_expando_with_finalizer_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(seconds: 60))
+@Timeout(Duration(seconds: 90))
 library;
 
 import 'dart:async';
@@ -49,7 +49,7 @@ Future<void> _encourageGC() async {
 
 /// Waits until condition true or timeout
 Future<void> _waitUntil(bool Function() cond,
-    {Duration timeout = const Duration(seconds: 10)}) async {
+    {Duration timeout = const Duration(seconds: 15)}) async {
   final start = DateTime.now();
   while (!cond()) {
     if (DateTime.now().difference(start) > timeout) {

--- a/test/swiss_knife_expando_with_finalizer_test.dart
+++ b/test/swiss_knife_expando_with_finalizer_test.dart
@@ -60,6 +60,10 @@ Future<void> _waitUntil(bool Function() cond,
 }
 
 void main() {
+  tearDown(() async {
+    await _encourageGC();
+  });
+
   group('ExpandoWithFinalizer basic behavior', () {
     test('set + get', () {
       final exp = ExpandoWithFinalizer<_Key, String>((_) {});
@@ -70,6 +74,16 @@ void main() {
       expect(exp.get(key), 'hello');
       expect(exp.containsKey(key), true);
       expect(exp[key], 'hello');
+    });
+
+    test('containsKey remains true after replace', () {
+      final exp = ExpandoWithFinalizer<_Key, String>((_) {});
+      final key = _Key(1);
+
+      exp[key] = 'a';
+      exp[key] = 'b';
+
+      expect(exp.containsKey(key), true);
     });
 
     test('replace value', () {
@@ -93,6 +107,16 @@ void main() {
       expect(removed, 'value');
       expect(exp.containsKey(key), false);
       expect(exp.get(key), null);
+    });
+
+    test('remove twice returns null second time', () {
+      final exp = ExpandoWithFinalizer<_Key, String>((_) {});
+      final key = _Key(2);
+
+      exp[key] = 'value';
+
+      expect(exp.remove(key), 'value');
+      expect(exp.remove(key), null);
     });
   });
 
@@ -177,5 +201,143 @@ void main() {
       expect(finalized, ['same']);
       expect(exp.get(_Key(40)), null);
     });
+
+    test('finalizer fires only once per association', () async {
+      final finalized = <String>[];
+
+      final exp = ExpandoWithFinalizer<_Key, String>((v) {
+        finalized.add(v);
+      });
+
+      void createKey() {
+        final key = _Key(50);
+        exp[key] = 'once';
+      }
+
+      createKey();
+
+      await _waitUntil(() => finalized.isNotEmpty);
+
+      await _encourageGC();
+      await Future.delayed(const Duration(milliseconds: 200));
+
+      expect(finalized, ['once']);
+    });
+
+    test('multiple keys finalize independently', () async {
+      final finalized = <String>[];
+
+      final exp = ExpandoWithFinalizer<_Key, String>((v) {
+        finalized.add(v);
+      });
+
+      void createKeys() {
+        exp[_Key(1)] = 'a';
+        exp[_Key(2)] = 'b';
+        exp[_Key(3)] = 'c';
+      }
+
+      createKeys();
+
+      await _waitUntil(() => finalized.length == 3);
+
+      expect(finalized.toSet(), {'a', 'b', 'c'});
+    });
+
+    test('onFinalizeError called when callback throws', () async {
+      Object? capturedError;
+
+      final exp = _TestExpando(
+        (_) => throw StateError('boom'),
+        onError: (e) => capturedError = e,
+      );
+
+      void createKey() {
+        exp[_Key(60)] = 'x';
+      }
+
+      createKey();
+
+      await _waitUntil(() => capturedError != null);
+
+      expect(capturedError, isA<StateError>());
+    });
+
+    test('debug wrapper does not keep key alive', () async {
+      final finalized = <String>[];
+
+      final exp = ExpandoWithFinalizer<_Key, String>((v) => finalized.add(v),
+          debug: true);
+
+      void createKey() {
+        final key = _Key(70);
+        exp[key] = 'debug';
+      }
+
+      createKey();
+
+      await _waitUntil(() => finalized.contains('debug'));
+
+      expect(finalized, ['debug']);
+    });
+
+    test('identical value does not replace wrapper', () {
+      final exp = ExpandoWithFinalizer<_Key, Object>((_) {});
+      final key = _Key(80);
+
+      final value = Object();
+
+      exp.put(key, value);
+
+      final wrapper1 = exp.getWrapper(key);
+
+      exp.put(key, value);
+
+      final wrapper2 = exp.getWrapper(key);
+
+      expect(identical(wrapper1, wrapper2), true);
+    });
   });
+
+  group('AttachOnlyFinalizer', () {
+    test('remove throws', () {
+      final f = AttachOnlyFinalizer<_Key, String>((_) {});
+
+      expect(
+        () => f.remove(_Key(1)),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('finalizer runs', () async {
+      final finalized = <String>[];
+
+      final f = AttachOnlyFinalizer<_Key, String>((v) {
+        finalized.add(v);
+      });
+
+      void createKey() {
+        final key = _Key(90);
+        f.put(key, 'value');
+      }
+
+      createKey();
+
+      await _waitUntil(() => finalized.isNotEmpty);
+
+      expect(finalized, ['value']);
+    });
+  });
+}
+
+class _TestExpando<K extends Object, V extends Object>
+    extends ExpandoWithFinalizer<K, V> {
+  final void Function(Object error)? onError;
+
+  _TestExpando(super.cb, {this.onError});
+
+  @override
+  void onFinalizeError(Object error, StackTrace stackTrace) {
+    onError?.call(error);
+  }
 }

--- a/test/swiss_knife_weak_map_test.dart
+++ b/test/swiss_knife_weak_map_test.dart
@@ -27,9 +27,21 @@ class ValueObj {
 }
 
 void main() {
+  group('WeakReference', () {
+    _doTests();
+  });
+
+  group('LazyWeakReference', () {
+    _doTests(LazyWeakReferenceManager(), LazyWeakReferenceManager());
+  });
+}
+
+void _doTests(
+    [LazyWeakReferenceManager<KeyObj>? keyManager,
+    LazyWeakReferenceManager<ValueObj>? valueManager]) {
   group('WeakKeyMap', () {
     test('put and get', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -41,7 +53,7 @@ void main() {
     });
 
     test('containsKey and containsValue', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -53,7 +65,7 @@ void main() {
     });
 
     test('remove returns value and deletes entry', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -68,7 +80,7 @@ void main() {
     });
 
     test('iterate visits all entries', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k1 = KeyObj(1);
       final k2 = KeyObj(2);
@@ -107,7 +119,7 @@ void main() {
     });
 
     test('keys, values and entries reflect current state', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k1 = KeyObj(1);
       final k2 = KeyObj(2);
@@ -126,7 +138,7 @@ void main() {
     });
 
     test('entriesSwapped returns value->key pairs', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -139,7 +151,7 @@ void main() {
     });
 
     test('removeWhere removes matching entries', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k1 = KeyObj(1);
       final k2 = KeyObj(2);
@@ -155,7 +167,7 @@ void main() {
     });
 
     test('containsKey and get are null/type safe', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       map[KeyObj(1)] = ValueObj('a');
 
@@ -166,7 +178,7 @@ void main() {
     });
 
     test('clear resets length and state', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       map[KeyObj(1)] = ValueObj('a');
       map.clear();
@@ -177,7 +189,7 @@ void main() {
     });
 
     test('getEntry returns MapEntry when key and value are alive', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -192,7 +204,7 @@ void main() {
     });
 
     test('getEntry returns null for missing or invalid keys', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       map[KeyObj(1)] = ValueObj('a');
 
@@ -202,7 +214,7 @@ void main() {
     });
 
     test('getEntry reflects removals', () {
-      final map = WeakKeyMap<KeyObj, ValueObj>();
+      final map = _newWeakKeyMap(keyManager);
 
       final k = KeyObj(1);
       map[k] = ValueObj('a');
@@ -215,7 +227,7 @@ void main() {
 
   group('DualWeakMap', () {
     test('put and get by key', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -227,7 +239,7 @@ void main() {
     });
 
     test('swapped map get by value', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
       final swapped = map.swapped;
 
       final k = KeyObj(1);
@@ -239,7 +251,7 @@ void main() {
     });
 
     test('swapped assignment overwrites correctly', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
       final swapped = map.swapped;
 
       final k1 = KeyObj(1);
@@ -255,7 +267,7 @@ void main() {
     });
 
     test('remove via swapped map', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
       final swapped = map.swapped;
 
       final k = KeyObj(1);
@@ -270,7 +282,7 @@ void main() {
     });
 
     test('clear clears both directions', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       map[KeyObj(1)] = ValueObj('a');
       map[KeyObj(2)] = ValueObj('b');
@@ -282,7 +294,7 @@ void main() {
     });
 
     test('keys and values views are swapped correctly', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       final k1 = KeyObj(1);
       final k2 = KeyObj(2);
@@ -301,7 +313,7 @@ void main() {
     });
 
     test('swapped assignment with same mapping is a no-op', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
       final swapped = map.swapped;
 
       final k = KeyObj(1);
@@ -315,7 +327,7 @@ void main() {
     });
 
     test('removing by key removes value mapping too', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
       final swapped = map.swapped;
 
       final k = KeyObj(1);
@@ -329,7 +341,7 @@ void main() {
     });
 
     test('entries and swapped entries stay consistent', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -346,7 +358,7 @@ void main() {
     });
 
     test('getKeyFromValue returns key for existing value', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -359,7 +371,7 @@ void main() {
     });
 
     test('getKeyFromValue returns null for unknown value', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       map[KeyObj(1)] = ValueObj('a');
 
@@ -367,7 +379,7 @@ void main() {
     });
 
     test('getKeyFromValue is null- and type-safe', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       map[KeyObj(1)] = ValueObj('a');
 
@@ -376,7 +388,7 @@ void main() {
     });
 
     test('getKeyFromValue reflects removals', () {
-      final map = DualWeakMap<KeyObj, ValueObj>();
+      final map = _newDualWeakMap(keyManager, valueManager);
 
       final k = KeyObj(1);
       final v = ValueObj('a');
@@ -388,3 +400,13 @@ void main() {
     });
   });
 }
+
+WeakKeyMap<KeyObj, ValueObj> _newWeakKeyMap(
+        LazyWeakReferenceManager<KeyObj>? keyManager) =>
+    WeakKeyMap<KeyObj, ValueObj>.configured(keyLazyRefManager: keyManager);
+
+DualWeakMap<KeyObj, ValueObj> _newDualWeakMap(
+        LazyWeakReferenceManager<KeyObj>? keyManager,
+        LazyWeakReferenceManager<ValueObj>? valueManager) =>
+    DualWeakMap<KeyObj, ValueObj>.configured(
+        keyLazyRefManager: keyManager, valueLazyRefManager: valueManager);


### PR DESCRIPTION
- `TreeReferenceMap`:
  - Replaced `_purged` field type from `DualWeakMap` to `DualLazyWeakMap`.
  - Use global `LazyWeakReferenceManagerByType` to create `DualLazyWeakMap` instances for purged entries.

- `ExpandoWithFinalizer`:
  - Refactored to extend generic `WithFinalizer` base class.
  - Introduced strongly typed `FinalizerValueWrapper` abstraction and concrete implementations:
    - `SimpleFinalizerWrapper`, `SimpleFinalizerWrapperDebug`
    - `ExpandoValueWrapper`, `ExpandoValueWrapperDebug`
  - Added `AttachOnlyFinalizer` class for write-only finalizer usage.
  - Added `debug` mode to retain weak references to keys for inspection.
  - Improved finalizer attach/detach logic and wrapper management.

- `lazy_weak_reference.dart`:
  - Added `GenericReference` interface for strong/weak reference abstraction.
  - Added `LazyWeakReferenceManagerByType` singleton managing per-type `LazyWeakReferenceManager` instances.
  - Added `toString` and `compareTo` improvements to `LazyWeakReference`.
  - Added `LazyWeakReferenceManagerByType` class for centralized management.
  - Added `toString` override to `LazyWeakReferenceManager`.

- `weak_map.dart`:
  - Refactored internal entry classes to support lazy weak references:
    - Added `_EntryLazyRef`, `_EntryLazyRef1`, `_EntryLazyRef2`, `_EntryLazyRefValue`.
  - Added `LazyWeakKeyMap` subclass using lazy weak references for keys.
  - Added `DualLazyWeakMap` subclass using lazy weak references for keys and values.
  - Added factory constructors `WeakKeyMap.configured` and `DualWeakMap.configured` to create lazy weak reference variants.
  - Added `removeWhereKey` extension method on `Map` and `WeakKeyMap`.
  - Updated purge logic to use `removeWhereKey`.
  - Updated `DualWeakMap` to optionally use lazy weak references for keys and values.

- `resource.dart`:
  - Changed `ResourceContentCache` to use private `_onLoadEventStream` instead of public `onLoad` field.
  - Updated `ResourceContent` to lazily initialize `_onLoadEventStream` and use it internally.
  - Changed event notification to use `_onLoadEventStream?.add` instead of `onLoad.add`.